### PR TITLE
Fix: BLEURT was failing when the input batch size is 1

### DIFF
--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -100,7 +100,7 @@ class BLEURT(datasets.Metric):
             }   
             
             with torch.no_grad():
-                outputs = self.model(**inputs)['logits'].squeeze()
+                outputs = self.model(**inputs)['logits'].squeeze(-1)
 
             if adjusted:
                 outputs = 1 / (1 + 2 ** (-4 * outputs)) # scaled sigmoid


### PR DESCRIPTION
`squeeze()` without params removes _all_ dimensions of size 1. This turned `outputs` into a scalar when scoring a single pair of sentences and resulted in an error 

## Before the fix
```
>>> bleurt.compute(references=['the dog sat'], predictions=['the cat sat'])
...
bleurt.py:108, in BLEURT._compute(self, predictions, references, batch_size, device, adjusted)                                                                                                                                                               105     if adjusted:
    106         outputs = 1 / (1 + 2 ** (-4 * outputs)) # scaled sigmoid
--> 108     scores += outputs.tolist()
    110 return {
    111     "scores": scores,
    112 }

TypeError: 'float' object is not iterable
```

## After the fix

```
>>> bleurt.compute(references=['the dog sat'], predictions=['the cat sat'])
 {'scores': [0.7950546145439148]}
```